### PR TITLE
test data and refining gxf parsing code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,4 @@ lib/__pycache__
 lib/*.pyc
 *.code-workspace
 *.errlog
+test-data/

--- a/degenotate.py
+++ b/degenotate.py
@@ -14,7 +14,7 @@ import lib.params as params
 import lib.opt_parse as OP
 import lib.gxf as gxf
 import lib.seq as SEQ
-# import lib.degen as degen
+import lib.degen as degen
 # import lib.output as OUT
 ## TODO: Commented libaries need to be created
 
@@ -29,10 +29,10 @@ if __name__ == '__main__':
     print("\n" + " ".join(sys.argv) + "\n");
 
     if any(v in sys.argv for v in ["--version", "-version", "--v", "-v"]):
-        print("# PhyloAcc version " + globs['interface-version'] + " released on " + globs['releasedate'])
+        print("# degenotate version " + globs['version'] + " released on " + globs['releasedate'])
         sys.exit(0);
     # The version option to simply print the version and exit.
-    # Need to get actual PhyloAcc version for this, and not just the interface version.
+    # Need to get actual degenotate version for this, and not just the interface version.
 
     print("#");
     print("# " + "=" * 125);
@@ -76,7 +76,10 @@ if __name__ == '__main__':
     #     # Read the individual coding sequences         
     ## TODO: Function to read sequences from file(s)
 
+    step = "Caclulating degeneracy per transcript";
+    step_start_time = CORE.report_step(globs, step, False, "In progress...");
     globs = degen.calcDegen(globs)
+    step_start_time = CORE.report_step(globs, step, step_start_time, "Success");
     
     # globs = OUT.writeDegen(globs);
     ## TODO: Function to write output. NEED TO CREATE OUTPUT LIBRARY

--- a/lib/degen.py
+++ b/lib/degen.py
@@ -2,6 +2,7 @@
 # Functions to compute degeneracy for CDS sequences in degenotate
 #############################################################################
 
+import os
 import csv
 import re
 
@@ -21,7 +22,7 @@ def readDegen():
 #     mutations are synonymous
 
     DEGEN_DICT = {}
-    with open(os.path.join(os.path.dirname(__file__), "codon_table.tsv"), "r") as dd:
+    with open(os.path.join(os.path.dirname(__file__), "codon_table.csv"), "r") as dd:
         reader = csv.reader(dd)
         DEGEN_DICT = {rows[0]:rows[1] for rows in reader}
 
@@ -32,7 +33,7 @@ def readDegen():
 
 def frameError(seq,frame):
 
-#Check that the sequence is the correct muliple of three for the starting frame
+#Check that the sequence is the correct multiple of three for the starting frame
 
     seq_mod = len(seq) % 3
     if frame == 1 and seq_mod == 0:
@@ -51,19 +52,19 @@ def calcDegen(globs):
 
     DEGEN_DICT = readDegen()
 
-    for transcript in globs['cds-seq']:
+    for transcript in globs['cds-seqs']:
         #use dict.get() to return value or a default option if key doesn't exist
         #assumes that globs['annotation'][transcript]['start-frame'] won't exist
         #unless start frame was parsed from GFF
         frame = globs['annotation'][transcript].get('start-frame', 1)
 
         #check frame
-        if frameError(globs['cds-seq'][transcript],frame):
+        if frameError(globs['cds-seqs'][transcript],frame):
             continue
         ## TO DO: ADD ERROR REPORTING FOR FRAME ERRORS
 
         #if frame is not 1, need to skip the first frame-1 bases
-        fasta = globs['cds-seq'][transcript][frame:]
+        fasta = globs['cds-seqs'][transcript][frame:]
 
         #also add . (degeneracy cannot be called) to frame-1 beginning of degeneracy string
         globs['annotation'][transcript] = "." * (frame-1) if frame > 1 else ""
@@ -76,6 +77,8 @@ def calcDegen(globs):
         #TO DO: error checking
         degen = [DEGEN_DICT(x) for x in codons]
 
-        globs['degenercy'][transcript] = "".join(degen)
+        globs['degeneracy'][transcript] = "".join(degen)
 
         return globs
+
+#############################################################################

--- a/lib/gxf.py
+++ b/lib/gxf.py
@@ -23,10 +23,68 @@ def checkIDs(l, info, id_list, step, globs):
 
 #############################################################################
 
-# def readFeatures(feature_list, get_id=True, id_format, get_parent=True, parent_id_format, info_field_splitter)
+def readFeatures(globs, file_reader, line_reader, feature_list, id_format, parent_id_format, info_field_splitter):
 
-#     return globs, num_read, num_missing
-## TODO: Generalize the loops for each feature so we don't have all this copied code
+    num_features = 0;
+    for line in file_reader(globs['gxf-file']):
+            line = line_reader(line);
+            # Read and parse the current line of the GXF file
+
+            if "##FASTA" in line[0]:
+                break;
+            # Maker GFF files sometimes include the sequence of all transcripts at the end. We need to stop reading the file
+            # at that point.
+
+            if line[0][0] == "#":
+                continue;
+            # Header/comment lines should be skipped. Note that this must come after the check for "##FASTA" above, or else
+            # the file will keep being read into the sequences and error out.
+
+            feature_type, seq_header, start, end, strand, feature_info = line[2], line[0], int(line[3]), int(line[4]), line[6], line[8].split(info_field_splitter);
+            # Unpack the pertinent information from the current line into more readable variables.
+
+            if feature_type in feature_list:
+            # Skipping any 'unconfirmed_transcript'
+                feature_id = [ info_field for info_field in feature_info if info_field.startswith(id_format) ];
+                # Get the feature ID as a list of fields with the "ID=" prefix
+
+                # print(feature_info);
+                # print(feature_id);
+                # sys.exit();
+
+                checkIDs(line, feature_info, feature_id, feature_list[0] +" id parsing", globs);
+                # A quick check to make sure we have read only one ID
+
+                feature_id = feature_id[0].replace(id_format, "").replace("\"", "");
+                # Unpack and parse the ID
+
+                parent_id = [ info_field for info_field in feature_info if info_field.startswith(parent_id_format) ];
+                # Get the gene ID associated with the transcript as a list of fields with the "Parent=" prefix
+
+                checkIDs(line, feature_info, parent_id, feature_list[0] +" parent id parsing", globs);
+                # A quick check to make sure we have read only one ID
+
+                parent_id = parent_id[0].replace(parent_id_format, "").replace("\"", "");
+                # Unpack and parse the gene ID
+
+                if feature_list[0] == "transcript":
+                    globs['annotation'][feature_id] = { 'header' : seq_header, 'start' : start, 'end' : end, 'strand' : strand, 'exons' : {}, "gene-id" : parent_id };
+                    # Add the ID and related info to the annotation dict. This includes an empty dict for exons to be stored in a similar way
+
+                elif feature_list[0] == "CDS":
+                    num_exons = len(globs['annotation'][parent_id]['exons']);
+                    exon_id = "exon-" + str(num_exons+1);
+                    # Because exon IDs are not always included for CDS, or they only represent the CDS as a whole (e.g. protein ID from Ensembl), we 
+                    # count the number of exons in the transcript as the ID
+
+                    globs['annotation'][parent_id]['exons'][exon_id] = { 'header' : seq_header, 'start' : start, 'end' : end, 'strand' : strand };
+                # Add the ID and related info to the annotation dict.                   
+
+                num_features += 1;
+                # Add to the number of transcripts read
+
+
+    return globs['annotation'], num_features;
 
 #############################################################################
 
@@ -64,218 +122,77 @@ def read(globs):
 
     globs['annotation'] = {};
     # The main annotation storage dict. A nested structure for genes, transcripts, and coding exons.
-    # <gene id> : { <header>, <start coord>, <end coord>, <strand>, 
-    #                   { <transcript id> : <transcript header>, <transcript start coord>, <transcript end coord> <transcript strand>, 
+    # <transcript id> : { <header>, <start coord>, <end coord>, <strand>, 
     #                       { <exon id> : <exon header>, <exon start coord>, <exon end coord>, <exon strand> } } }
-    ## TODO: Restructure to remove gene id as main key. Some annotation formats (UCSC gtf) do not include genes as features, and
-    ##       it isn't necessary to have them in this dictionary as the main key. I still think it is useful to have their IDs
-    ##       associated with transcripts whenever possible.
 
-    ####################
-
-    step = "Reading genes";
-    step_start_time = CORE.report_step(globs, step, False, "In progress...");
-
-    for line in reader(globs['gxf-file']):
-        line = readline(line);
-        # Read and parse the current line of the GXF file
-
-        if "##FASTA" in line[0]:
-            break;
-        # Maker GFF files sometimes include the sequence of all transcripts at the end. We need to stop reading the file
-        # at that point
-
-        if line[0][0] == "#":
-            continue;
-        # Header/comment lines should be skipped. Note that this must come after the check for "##FASTA" above, or else
-        # the file will keep being read into the sequences and error out
-
-        feature_type, seq_header, start, end, strand, feature_info = line[2], line[0], int(line[3]), int(line[4]), line[6], line[8].split(field_splitter);
-        # Unpack the pertinent information from the current line into more readable variables
-
-        if feature_type == "gene":
-            feature_id = [ info_field for info_field in feature_info if info_field.startswith(gene_id_format) ];
-            # Get the feature ID as a list of fields with the "ID=" prefix
-
-            checkIDs(line, feature_info, feature_id, "gene id parsing", globs);
-            # A quick check to make sure we have read only one ID
-
-            feature_id = feature_id[0].replace(gene_id_format, "").replace("\"", "");
-            # Unpack and parse the ID
-
-            globs['annotation'][feature_id] = { 'header' : seq_header, 'start' : start, 'end' : end, 'strand' : strand, 'transcripts' : {} };
-            # Add the ID and related info to the annotation dict. This includes an empty dict for transcripts to be stored in a similar way
-
-    step_start_time = CORE.report_step(globs, step, step_start_time, "Success: " + str(len(globs['annotation'])) + " genes read");
-    # Status update
-
-    # Read genes
     ####################
 
     step = "Reading transcripts";
     step_start_time = CORE.report_step(globs, step, False, "In progress...");
-
-    num_transcripts = 0;
-    # A count of the number of transcripts read
-
-    tid_to_gid = {};
-    # A dictionary to link each transcript to it's gene ID, necessary for reading in exons in the next step
-    # <transcript id> : <gene id>
-
-    missing_genes = [];
-    # Sometimes, transcripts will be present in the GXF file that have genes that don't have their own entry. This list
-    # keeps track of those genes to report later
-
-    for line in reader(globs['gxf-file']):
-        line = readline(line);
-        # Read and parse the current line of the GXF file
-
-        if "##FASTA" in line[0]:
-            break;
-        # Maker GFF files sometimes include the sequence of all transcripts at the end. We need to stop reading the file
-        # at that point.
-
-        if line[0][0] == "#":
-            continue;
-        # Header/comment lines should be skipped. Note that this must come after the check for "##FASTA" above, or else
-        # the file will keep being read into the sequences and error out.
-
-        feature_type, seq_header, start, end, strand, feature_info = line[2], line[0], int(line[3]), int(line[4]), line[6], line[8].split(field_splitter);
-        # Unpack the pertinent information from the current line into more readable variables.
-
-        if feature_type in ["transcript", "mRNA"]:
-        # Skipping any 'unconfirmed_transcript'
-            feature_id = [ info_field for info_field in feature_info if info_field.startswith(transcript_id_format) ];
-            # Get the feature ID as a list of fields with the "ID=" prefix
-
-            # print(feature_info);
-            # print(feature_id);
-            # sys.exit();
-
-            checkIDs(line, feature_info, feature_id, "transcript id parsing", globs);
-            # A quick check to make sure we have read only one ID
-
-            feature_id = feature_id[0].replace(transcript_id_format, "").replace("\"", "");
-            # Unpack and parse the ID
-
-            parent_id = [ info_field for info_field in feature_info if info_field.startswith(transcript_parent_format) ];
-            # Get the gene ID associated with the transcript as a list of fields with the "Parent=" prefix
-
-            checkIDs(line, feature_info, parent_id, "transcript parent id parsing", globs);
-            # A quick check to make sure we have read only one ID
-
-            parent_id = parent_id[0].replace(transcript_parent_format, "").replace("\"", "");
-            # Unpack and parse the gene ID
-
-            if parent_id not in globs['annotation']:
-                if parent_id not in missing_genes:
-                    missing_genes.append(parent_id);
-                continue;
-            # If the gene doesn't have it's own entry in the GXF file, add it to the list of missing genes and
-            # skip this transcript
-            else:
-                tid_to_gid[feature_id] = parent_id;
-            # Otherwise, add the transcript id/gene id pair to the lookup dict
-
-            globs['annotation'][parent_id]['transcripts'][feature_id] = { 'header' : seq_header, 'start' : start, 'end' : end, 'strand' : strand, 'exons' : {} };
-            # Add the ID and related info to the annotation dict. This includes an empty dict for exons to be stored in a similar way
-
-            num_transcripts += 1;
-            # Add to the number of transcripts read
-
+    globs['annotation'], num_transcripts = readFeatures(globs, reader, readline, ["transcript", "mRNA"], transcript_id_format, transcript_parent_format, field_splitter);
     step_start_time = CORE.report_step(globs, step, step_start_time, "Success: " + str(num_transcripts) + " transcripts read");
-    # Status update
-
-    CORE.printWrite(globs['logfilename'], globs['log-v'], "# INFO: " + str(len(missing_genes)) + " missing genes (present as parent of other feature, but not as its own feature)");  
-    #print("# INFO: " + str(len(missing_genes)) + " missing genes (present as parent of other feature, but not as its own feature)");
-    # Report the number of missing genes
 
     # Read transcripts
     ####################
 
     step = "Reading coding exons";
     step_start_time = CORE.report_step(globs, step, False, "In progress...");
-
-    num_cds_exons = 0;
-    # A count of the number of transcripts read
-
-    missing_transcripts = [];
-    # Sometimes, exons will be present in the GXF file that have transcripts that don't have their own entry. This list
-    # keeps track of those transcripts to report later
-
-    for line in reader(globs['gxf-file']):
-        line = readline(line);
-        # Read and parse the current line of the GXF file
-
-        if "##FASTA" in line[0]:
-            break;
-        # Maker GFF files sometimes include the sequence of all transcripts at the end. We need to stop reading the file
-        # at that point.
-
-        if line[0][0] == "#":
-            continue;
-        # Header/comment lines should be skipped. Note that this must come after the check for "##FASTA" above, or else
-        # the file will keep being read into the sequences and error out.
-
-        feature_type, seq_header, start, end, strand, feature_info = line[2], line[0], int(line[3]), int(line[4]), line[6], line[8].split(field_splitter);
-        # Unpack the pertinent information from the current line into more readable variables.
-
-        if feature_type in ["CDS"]:
-            feature_id = [ info_field for info_field in feature_info if info_field.startswith(exon_id_format) ];
-            # Get the feature ID as a list of fields with the "ID=" prefix
-
-            #checkIDs(line, feature_info, feature_id, "exon id parsing", globs);
-            # A quick check to make sure we have read only one ID
-
-            if feature_id:
-                feature_id = feature_id[0].replace(exon_id_format, "").replace("\"", "");
-            # Unpack and parse the ID
-
-            parent_id = [ info_field for info_field in feature_info if info_field.startswith(exon_parent_format) ];
-            # Get the transcript ID associated with the exon as a list of fields with the "Parent=" prefix
-
-            checkIDs(line, feature_info, parent_id, "exon parent id parsing", globs);
-            # A quick check to make sure we have read only one ID
-
-            parent_id = parent_id[0].replace(exon_parent_format, "").replace("\"", "");
-            # Unpack and parse the gene ID
-
-            if parent_id not in tid_to_gid:
-                if parent_id not in missing_transcripts:
-                    missing_transcripts.append(parent_id);
-                continue;
-            # If the transcript doesn't have it's own entry in the GXF file, add it to the list of missing transcripts and
-            # skip this exon
-            else:
-                gene_id = tid_to_gid[parent_id];
-            # Otherwise, lookup the gene ID associated with the transcript to use below
-
-            num_exons = len(globs['annotation'][gene_id]['transcripts'][parent_id]['exons']);
-            exon_id = "exon-" + str(num_exons+1);
-            # Because exon IDs are not always included for CDS, or they only represent the CDS as a whole (e.g. protein ID from Ensembl), we 
-            # count the number of exons in the transcript as the ID
-
-            globs['annotation'][gene_id]['transcripts'][parent_id]['exons'][exon_id] = { 'header' : seq_header, 'start' : start, 'end' : end, 'strand' : strand };
-            # Add the ID and related info to the annotation dict.
-
-            num_cds_exons += 1;
-            # Add to the number of exons read
-
+    globs['annotation'], num_cds_exons = readFeatures(globs, reader, readline, ["CDS"], exon_id_format, exon_parent_format, field_splitter);
     step_start_time = CORE.report_step(globs, step, step_start_time, "Success: " + str(num_cds_exons) + " coding exons read");
-    # Status update
 
-    CORE.printWrite(globs['logfilename'], globs['log-v'], "# INFO: " + str(len(missing_transcripts)) + " missing transcripts (present as parent of other feature, but not as its own feature)");  
-    #print("# INFO: " + str(len(missing_transcripts)) + " missing transcripts (present as parent of other feature, but not as its own feature)");
-    # Report the number of missing transcripts
+    # Read coding exons
+    ####################
 
     if num_cds_exons == 0:
         CORE.errorOut("GXF2", "No CDS exons found in input annotation file! Cannot calculate degeneracy without coding sequences.", globs);
     # Check to make sure at least one CDS sequence is found, otherwise error out
 
-    # Read coding exons
-    ####################
-
     return globs;
 
     #############################################################################
     
+
+
+
+
+
+    #############################################################################
+    
+    # step = "Reading genes";
+    # step_start_time = CORE.report_step(globs, step, False, "In progress...");
+
+    # for line in reader(globs['gxf-file']):
+    #     line = readline(line);
+    #     # Read and parse the current line of the GXF file
+
+    #     if "##FASTA" in line[0]:
+    #         break;
+    #     # Maker GFF files sometimes include the sequence of all transcripts at the end. We need to stop reading the file
+    #     # at that point
+
+    #     if line[0][0] == "#":
+    #         continue;
+    #     # Header/comment lines should be skipped. Note that this must come after the check for "##FASTA" above, or else
+    #     # the file will keep being read into the sequences and error out
+
+    #     feature_type, seq_header, start, end, strand, feature_info = line[2], line[0], int(line[3]), int(line[4]), line[6], line[8].split(field_splitter);
+    #     # Unpack the pertinent information from the current line into more readable variables
+
+    #     if feature_type == "gene":
+    #         feature_id = [ info_field for info_field in feature_info if info_field.startswith(gene_id_format) ];
+    #         # Get the feature ID as a list of fields with the "ID=" prefix
+
+    #         checkIDs(line, feature_info, feature_id, "gene id parsing", globs);
+    #         # A quick check to make sure we have read only one ID
+
+    #         feature_id = feature_id[0].replace(gene_id_format, "").replace("\"", "");
+    #         # Unpack and parse the ID
+
+    #         globs['annotation'][feature_id] = { 'header' : seq_header, 'start' : start, 'end' : end, 'strand' : strand, 'transcripts' : {} };
+    #         # Add the ID and related info to the annotation dict. This includes an empty dict for transcripts to be stored in a similar way
+
+    # step_start_time = CORE.report_step(globs, step, step_start_time, "Success: " + str(len(globs['annotation'])) + " genes read");
+    # # Status update
+
+    # # Old code to read genes
+    # ####################

--- a/lib/opt_parse.py
+++ b/lib/opt_parse.py
@@ -95,7 +95,7 @@ def optParse(globs):
             globs['in-seq-type'] = "directory";
     # Save the input type as a global param
 
-    globs = CORE.fileCheck(globs);
+    globs = CORE.fileCheck(globs); 
     # Make sure all the input files actually exist, and get their
     # full paths
 

--- a/lib/params.py
+++ b/lib/params.py
@@ -12,8 +12,19 @@ import lib.core as PC
 
 #############################################################################
 
+class StrictDict(dict):
+# This prevents additional keys from being added to the global params dict in
+# any other part of the code, just to help me limit it's scope
+# https://stackoverflow.com/questions/32258706/how-to-prevent-key-creation-through-dkey-val
+    def __setitem__(self, key, value):
+        if key not in self:
+            raise KeyError("{} is not a legal key of this StrictDict".format(repr(key)));
+        dict.__setitem__(self, key, value);
+
+#############################################################################
+
 def init():
-    globs = {
+    globs_init = {
         'version' : 'Beta 1.0',
         'releasedate' : "October 2021",
         'authors' : "Timothy Sackton, Gregg Thomas, Sara Wuitchik",
@@ -46,9 +57,6 @@ def init():
         'outdir' : '',
         'run-name' : 'degenotate',
         'logfilename' : 'degenotate.errlog',
-        # 'alnstatsfile' : 'phyloacc-aln-stats.csv',
-        # 'scfstatsfile' : 'phyloacc-scf-stats.csv',
-        # 'scftreefile' : 'phyloacc-scf.tree',
         'logdir' : '',
         'overwrite' : False,
         # I/O options
@@ -65,18 +73,6 @@ def init():
 
         'num-procs' : 1,
         # Number of processes to use
-
-        'aln-pool' : False,
-        'scf-pool' : False,
-        # Process pools
-
-        'job-dir' : '',
-        'job-alns' : '',
-        'job-cfgs' : '',
-        'job-bed' : '',
-        'job-smk' : '',
-        'job-out' : '',
-        # Job directories
 
         'info' : False,
         'dryrun' : False,
@@ -103,7 +99,10 @@ def init():
         # Internal stuff
     }
 
-    globs['logfilename'] = "phyloacc-" + globs['startdatetime'] + ".errlog";
+    globs_init['logfilename'] = "degenotate-" + globs_init['startdatetime'] + ".errlog";
     # Add the runtime to the error log file name.
+
+    globs = StrictDict(globs_init);
+    # Restrict the dict from having keys added to it after this
 
     return globs;


### PR DESCRIPTION
Commits in this pull request:

1. Add test data. Mouse (mm10) chromosome 19 sequences and annotation files from three different sources (UCSC, NCBI, and ENSEMBL). Current tests pass using NCBI's gff file.
2. Remov the gene id as the main key for the annotation dictionary. The main key is now the transcript ID, with the gene ID being another value in the transcript dict if it is available.
3. Generaliz the GXF parsing code by feature. This reduces duplicated code in the `gxf.py` library.