### PR TITLE
Fix errors in frame calculations

### DIFF
--- a/lib/degen.py
+++ b/lib/degen.py
@@ -217,7 +217,7 @@ def processCodons(globs):
 
                 if frame != 1:
                     for out_of_frame_pos in range(extra_leading_nt):
-                        outline = OUT.compileBedLine(globs, transcript, "", cds_coord, globs['cds-seqs'][transcript][cds_coord], "", "", "", ".", "");
+                        outline = OUT.compileBedLine(globs, transcript, transcript_region, cds_coord, globs['cds-seqs'][transcript][cds_coord], "", "", ".", ".", "");
                         bedfile.write("\t".join(outline) + "\n");
                         # Call the output function with blank values since there is no degeneracy at this position
                         # and write the output to the bed file 
@@ -256,7 +256,7 @@ def processCodons(globs):
 
                 if extra_trailing_nt != 0:
                     for out_of_frame_pos in range(extra_trailing_nt):
-                        outline = OUT.compileBedLine(globs, transcript, "", cds_coord, globs['cds-seqs'][transcript][cds_coord], "", "", "", ".", "");
+                        outline = OUT.compileBedLine(globs, transcript, transcript_region, cds_coord, globs['cds-seqs'][transcript][cds_coord], "", "", ".", ".", "");
                         bedfile.write("\t".join(outline) + "\n");
                         # Call the output function with blank values since there is no degeneracy at this position
                         # and write the output to the bed file 

--- a/lib/degen.py
+++ b/lib/degen.py
@@ -227,8 +227,6 @@ def processCodons(globs):
                 # If the CDS is not in frame 1, the bed output needs to be filled in for the leading bases that were removed
                 ##########
 
-                ## TODO: Add parsing for extra trailing nt like for above
-
                 for codon in codons:
                     try:
                         aa = CODON_DICT[codon];
@@ -244,14 +242,28 @@ def processCodons(globs):
                         bedfile.write("\t".join(outline) + "\n");
                         # Write the output from the current position to the bed file
 
-                        globs['annotation'][transcript][int(degen[cds_coord])] += 1;
+                        if degen[cds_coords] != ".":
+                            globs['annotation'][transcript][int(degen[cds_coord])] += 1;
                         # Increment the count for the current degeneracy for the transcript summary
+                        # Skip positions with unknown degeneracy ('.')
 
                         cds_coord += 1;
                         # Increment the position in the CDS
                     # End base loop
                     ##########
                 # End codon loop
+                ##########
+
+                if extra_trailing_nt != 0:
+                    for out_of_frame_pos in range(extra_trailing_nt):
+                        outline = OUT.compileBedLine(globs, transcript, "", cds_coord, globs['cds-seqs'][transcript][cds_coord], "", "", "", ".", "");
+                        bedfile.write("\t".join(outline) + "\n");
+                        # Call the output function with blank values since there is no degeneracy at this position
+                        # and write the output to the bed file 
+
+                        cds_coord += 1;
+                        # Increment the position in the CDS
+                # If the CDS has extra trailing bases, the bed output needs to be filled in for the leading bases that were removed
                 ##########
 
                 #globs['degeneracy'][transcript] = degen;

--- a/lib/degen.py
+++ b/lib/degen.py
@@ -198,7 +198,8 @@ def processCodons(globs):
 
             #if frame is not 1, need to skip the first frame-1 bases
             fasta = globs['cds-seqs'][transcript][extra_leading_nt:]
-            fasta = fasta[:-extra_trailing_nt]
+            if extra_trailing_nt > 0:
+                fasta = fasta[:-extra_trailing_nt]
  
             #make list of codons
             codons = re.findall('...', fasta)
@@ -225,6 +226,8 @@ def processCodons(globs):
                         # Increment the position in the CDS
                 # If the CDS is not in frame 1, the bed output needs to be filled in for the leading bases that were removed
                 ##########
+
+                ## TODO: Add parsing for extra trailing nt like for above
 
                 for codon in codons:
                     try:

--- a/lib/degen.py
+++ b/lib/degen.py
@@ -242,7 +242,7 @@ def processCodons(globs):
                         bedfile.write("\t".join(outline) + "\n");
                         # Write the output from the current position to the bed file
 
-                        if degen[cds_coords] != ".":
+                        if degen[cds_coord] != ".":
                             globs['annotation'][transcript][int(degen[cds_coord])] += 1;
                         # Increment the count for the current degeneracy for the transcript summary
                         # Skip positions with unknown degeneracy ('.')


### PR DESCRIPTION
This pull request updates the way partial transcripts are handled, to properly trim partial 5' and 3' exons from degeneracy calculations while still outputting them in the degeneracy bed file.