### PR TITLE
Getting starting frame from GXF files

### DIFF
--- a/lib/degen.py
+++ b/lib/degen.py
@@ -162,8 +162,6 @@ def processCodons(globs):
     with open(globs['outbed'], "w") as bedfile, open(globs['out-transcript'], "a") as transcriptfile:
         counter = 0;
         for transcript in globs['cds-seqs']:
-            
-            extra_trailing_nt = 0;
 
             if globs['gxf-file']:
                 transcript_region = globs['annotation'][transcript]['header'];
@@ -172,32 +170,31 @@ def processCodons(globs):
             # Get the genome region if the input was a gxf file+genome
 
             if globs['gxf-file']:
-                frame = globs['annotation'][transcript].get('start-frame', 1);
+                frame = globs['annotation'][transcript].get('start-frame', 0);
                 # use dict.get() to return value or a default option if key doesn't exist
                 # assumes that globs['annotation'][transcript]['start-frame'] won't exist
                 # unless start frame was parsed from GFF
 
-                #check frame
-                if frameError(globs['cds-seqs'][transcript],frame):
-                    extra_trailing_nt = len(globs['cds-seqs'][transcript]) % 3
-
-                # If frameError, that implies that the last codon is partial, so we need to trim 
-
             # Get the frame when input is a when input is a gxf+genome
             else:
                 frame = getFrame(globs['cds-seqs'][transcript]);
-                if frame != 1:
+                if frame != 0:
                     CORE.printWrite(globs['logfilename'], 3, "# WARNING: transcript " + transcript + " is partial with unknown frame....skipping");
                     globs['warnings'] += 1;                    
                     continue;
                     ## TODO: Add warning that transcript is skipped 
             # Get the frame when input is a dir/file of individual CDS seqs
+            # In this case we just check to make sure the sequence is a multiple of 3
 
             extra_leading_nt = globs['leading-bases'][int(frame)]
             # Look up the number of leading bases given the current frame
 
             #if frame is not 1, need to skip the first frame-1 bases
             fasta = globs['cds-seqs'][transcript][extra_leading_nt:]
+
+            #now check to see if there are still trailing bases
+            extra_trailing_nt = len(fasta) % 3
+
             if extra_trailing_nt > 0:
                 fasta = fasta[:-extra_trailing_nt]
  

--- a/lib/degen.py
+++ b/lib/degen.py
@@ -212,7 +212,7 @@ def processCodons(globs):
                 cds_coord = 0;
                 # Start the CDS coord counter
 
-                if frame != 1:
+                if frame != 0:
                     for out_of_frame_pos in range(extra_leading_nt):
                         outline = OUT.compileBedLine(globs, transcript, transcript_region, cds_coord, globs['cds-seqs'][transcript][cds_coord], "", "", ".", ".", "");
                         bedfile.write("\t".join(outline) + "\n");

--- a/lib/degen.py
+++ b/lib/degen.py
@@ -172,7 +172,7 @@ def processCodons(globs):
             if globs['gxf-file']:
                 frame = globs['annotation'][transcript]['start-frame']
 
-                if frame in None:
+                if frame is None:
                     CORE.printWrite(globs['logfilename'], 3, "# WARNING: transcript " + transcript + " has an unknown frame....skipping");
                     globs['warnings'] += 1;                    
                     continue;

--- a/lib/degen.py
+++ b/lib/degen.py
@@ -72,11 +72,11 @@ def getFrame(seq):
 # A function that returns the frame of a coding sequence
     seq_mod = len(seq) % 3;
     if seq_mod == 0:
-        return 1;
+        return 0;
     elif seq_mod == 2:
-        return 2;
+        return 1;
     elif seq_mod == 1:
-        return 3;
+        return 2;
 
 #############################################################################
 
@@ -84,11 +84,11 @@ def frameError(seq,frame):
 # Check that the sequence is the correct multiple of three for the starting frame
 
     seq_mod = len(seq) % 3
-    if frame == 1 and seq_mod == 0:
+    if frame == 0 and seq_mod == 0:
         return False
-    elif frame == 2 and seq_mod == 2:
+    elif frame == 1 and seq_mod == 2:
         return False
-    elif frame == 3 and seq_mod == 1:
+    elif frame == 2 and seq_mod == 1:
         return False
     else:
         return True

--- a/lib/degen.py
+++ b/lib/degen.py
@@ -188,7 +188,7 @@ def processCodons(globs):
             # Get the frame when input is a dir/file of individual CDS seqs
             # In this case we just check to make sure the sequence is a multiple of 3
 
-            extra_leading_nt = globs['leading-bases'][frame]
+            extra_leading_nt = frame
             # Look up the number of leading bases given the current frame
 
             #if frame is not 1, need to skip the first frame-1 bases

--- a/lib/degen.py
+++ b/lib/degen.py
@@ -202,9 +202,10 @@ def processCodons(globs):
  
             #make list of codons
             codons = re.findall('...', fasta)
+            nt = {'A', 'T', 'G', 'C'}
 
             if ("degen" in globs['codon-methods']):
-                degen = [ DEGEN_DICT[x] if "N" not in x else "..." for x in codons ];
+                degen = [ DEGEN_DICT[x] if len(set(x) - nt) == 0 else "..." for x in codons ];
                 # Get the string of degeneracy integers for every codon in the current sequence (e.g. 002)
 
                 degen = "." * extra_leading_nt + "".join(degen);

--- a/lib/degen.py
+++ b/lib/degen.py
@@ -170,10 +170,12 @@ def processCodons(globs):
             # Get the genome region if the input was a gxf file+genome
 
             if globs['gxf-file']:
-                frame = globs['annotation'][transcript].get('start-frame', 0);
-                # use dict.get() to return value or a default option if key doesn't exist
-                # assumes that globs['annotation'][transcript]['start-frame'] won't exist
-                # unless start frame was parsed from GFF
+                frame = globs['annotation'][transcript]['start-frame']
+
+                if frame in None:
+                    CORE.printWrite(globs['logfilename'], 3, "# WARNING: transcript " + transcript + " has an unknown frame....skipping");
+                    globs['warnings'] += 1;                    
+                    continue;
 
             # Get the frame when input is a when input is a gxf+genome
             else:
@@ -186,7 +188,7 @@ def processCodons(globs):
             # Get the frame when input is a dir/file of individual CDS seqs
             # In this case we just check to make sure the sequence is a multiple of 3
 
-            extra_leading_nt = globs['leading-bases'][int(frame)]
+            extra_leading_nt = globs['leading-bases'][frame]
             # Look up the number of leading bases given the current frame
 
             #if frame is not 1, need to skip the first frame-1 bases

--- a/lib/degen.py
+++ b/lib/degen.py
@@ -193,7 +193,7 @@ def processCodons(globs):
                     ## TODO: Add warning that transcript is skipped 
             # Get the frame when input is a dir/file of individual CDS seqs
 
-            extra_leading_nt = globs['leading-bases'][frame]
+            extra_leading_nt = globs['leading-bases'][int(frame)]
             # Look up the number of leading bases given the current frame
 
             #if frame is not 1, need to skip the first frame-1 bases

--- a/lib/gxf.py
+++ b/lib/gxf.py
@@ -88,7 +88,7 @@ def readFeatures(globs, file_reader, line_reader, feature_list, id_format, paren
                         continue;
                     #if we find a CDS without an associated transcript, skip it
 
-                    exon_id = "exon-" + str(num_exons+1);q
+                    exon_id = "exon-" + str(num_exons+1);
                     # Because exon IDs are not always included for CDS, or they only represent the CDS as a whole (e.g. protein ID from Ensembl), we 
                     # count the number of exons in the transcript as the ID
 

--- a/lib/gxf.py
+++ b/lib/gxf.py
@@ -93,10 +93,10 @@ def readFeatures(globs, file_reader, line_reader, feature_list, id_format, paren
                     globs['annotation'][parent_id]['cdslen'] += end-start;
 
                     if strand == "+" and num_exons == 0:
-                        globs['annotation'][transcript]['start-frame'] = frame;
+                        globs['annotation'][parent_id]['start-frame'] = frame;
                     
                     if strand == "-":
-                        globs['annotation'][transcript]['start-frame'] = frame;
+                        globs['annotation'][parent_id]['start-frame'] = frame;
                     
                     #If on the positive strand, the starting frame is always the frame of the first exon we encounter
                     #If on the negative strand, the starting frame is awlays the frame of the last exon we encounter, so we just update it each time we see a new exon

--- a/lib/gxf.py
+++ b/lib/gxf.py
@@ -41,7 +41,7 @@ def readFeatures(globs, file_reader, line_reader, feature_list, id_format, paren
             # Header/comment lines should be skipped. Note that this must come after the check for "##FASTA" above, or else
             # the file will keep being read into the sequences and error out.
 
-            feature_type, seq_header, start, end, strand, frame, feature_info = line[2], line[0], int(line[3]), int(line[4]), line[6], int(line[7]), line[8].split(info_field_splitter);
+            feature_type, seq_header, start, end, strand, frame, feature_info = line[2], line[0], int(line[3]), int(line[4]), line[6], line[7], line[8].split(info_field_splitter);
             # Unpack the pertinent information from the current line into more readable variables.
 
             if feature_type in feature_list:
@@ -93,10 +93,10 @@ def readFeatures(globs, file_reader, line_reader, feature_list, id_format, paren
                     globs['annotation'][parent_id]['cdslen'] += end-start;
 
                     if strand == "+" and num_exons == 0:
-                        globs['annotation'][parent_id]['start-frame'] = frame;
+                        globs['annotation'][parent_id]['start-frame'] = int(frame);
                     
                     if strand == "-":
-                        globs['annotation'][parent_id]['start-frame'] = frame;
+                        globs['annotation'][parent_id]['start-frame'] = int(frame);
                     
                     #If on the positive strand, the starting frame is always the frame of the first exon we encounter
                     #If on the negative strand, the starting frame is awlays the frame of the last exon we encounter, so we just update it each time we see a new exon

--- a/lib/gxf.py
+++ b/lib/gxf.py
@@ -46,15 +46,6 @@ def readFeatures(globs, file_reader, line_reader, feature_list, id_format, paren
 
             if feature_type in feature_list:
             # Skipping any 'unconfirmed_transcript'
-                feature_id = [ info_field for info_field in feature_info if info_field.startswith(id_format) ];
-                # Get the feature ID as a list of fields with the "ID=" prefix
-
-                # print(feature_info);
-                # print(feature_id);
-                # sys.exit();
-
-                feature_id = feature_id[0].replace(id_format, "").replace("\"", "");
-                # Unpack and parse the ID
 
                 parent_id = [ info_field for info_field in feature_info if info_field.startswith(parent_id_format) ];
                 # Get the gene ID associated with the transcript as a list of fields with the "Parent=" prefix
@@ -67,8 +58,14 @@ def readFeatures(globs, file_reader, line_reader, feature_list, id_format, paren
 
                 if feature_list[0] == "transcript":
 
+                    feature_id = [ info_field for info_field in feature_info if info_field.startswith(id_format) ];
+                    # Get the feature ID as a list of fields with the "ID=" prefix
+                
                     checkIDs(line, feature_info, feature_id, feature_list[0] +" id parsing", globs);
                     # A quick check to make sure we have read only one ID
+
+                    feature_id = feature_id[0].replace(id_format, "").replace("\"", "");
+                    # Unpack and parse the ID
 
                     globs['annotation'][feature_id] = { 'header' : seq_header, 'start' : start, 'end' : end, 'len' : end-start, 'longest' : "no", 'cdslen': 0, 'strand' : strand, 
                                                         'exons' : {}, "gene-id" : parent_id, 'start-frame' : "",

--- a/lib/gxf.py
+++ b/lib/gxf.py
@@ -41,7 +41,7 @@ def readFeatures(globs, file_reader, line_reader, feature_list, id_format, paren
             # Header/comment lines should be skipped. Note that this must come after the check for "##FASTA" above, or else
             # the file will keep being read into the sequences and error out.
 
-            feature_type, seq_header, start, end, strand, frame, feature_info = line[2], line[0], int(line[3]), int(line[4]), line[6], line[7], line[8].split(info_field_splitter);
+            feature_type, seq_header, start, end, strand, frame, feature_info = line[2], line[0], int(line[3]), int(line[4]), line[6], int(line[7]), line[8].split(info_field_splitter);
             # Unpack the pertinent information from the current line into more readable variables.
 
             if feature_type in feature_list:
@@ -93,10 +93,10 @@ def readFeatures(globs, file_reader, line_reader, feature_list, id_format, paren
                     globs['annotation'][parent_id]['cdslen'] += end-start;
 
                     if strand == "+" and num_exons == 0:
-                        globs['annotation'][parent_id]['start-frame'] = int(frame);
+                        globs['annotation'][parent_id]['start-frame'] = frame;
                     
                     if strand == "-":
-                        globs['annotation'][parent_id]['start-frame'] = int(frame);
+                        globs['annotation'][parent_id]['start-frame'] = frame;
                     
                     #If on the positive strand, the starting frame is always the frame of the first exon we encounter
                     #If on the negative strand, the starting frame is awlays the frame of the last exon we encounter, so we just update it each time we see a new exon

--- a/lib/gxf.py
+++ b/lib/gxf.py
@@ -86,7 +86,7 @@ def readFeatures(globs, file_reader, line_reader, feature_list, id_format, paren
                         continue;
                     #if we find a CDS without an associated transcript, skip it
 
-                    exon_id = "exon-" + str(num_exons+1);
+                    exon_id = "exon-" + str(num_exons+1);q
                     # Because exon IDs are not always included for CDS, or they only represent the CDS as a whole (e.g. protein ID from Ensembl), we 
                     # count the number of exons in the transcript as the ID
 

--- a/lib/gxf.py
+++ b/lib/gxf.py
@@ -52,9 +52,6 @@ def readFeatures(globs, file_reader, line_reader, feature_list, id_format, paren
                 # print(feature_id);
                 # sys.exit();
 
-                checkIDs(line, feature_info, feature_id, feature_list[0] +" id parsing", globs);
-                # A quick check to make sure we have read only one ID
-
                 feature_id = feature_id[0].replace(id_format, "").replace("\"", "");
                 # Unpack and parse the ID
 
@@ -68,6 +65,11 @@ def readFeatures(globs, file_reader, line_reader, feature_list, id_format, paren
                 # Unpack and parse the gene ID
 
                 if feature_list[0] == "transcript":
+
+                    checkIDs(line, feature_info, feature_id, feature_list[0] +" id parsing", globs);
+                    # A quick check to make sure we have read only one ID
+
+
                     globs['annotation'][feature_id] = { 'header' : seq_header, 'start' : start, 'end' : end, 'len' : end-start, 'longest' : "no", 'cdslen': 0, 'strand' : strand, 
                                                         'exons' : {}, "gene-id" : parent_id, 'start-frame' : "",
                                                         0 : 0, 2 : 0, 3 : 0, 4 : 0 };

--- a/lib/gxf.py
+++ b/lib/gxf.py
@@ -68,7 +68,7 @@ def readFeatures(globs, file_reader, line_reader, feature_list, id_format, paren
                     # Unpack and parse the ID
 
                     globs['annotation'][feature_id] = { 'header' : seq_header, 'start' : start, 'end' : end, 'len' : end-start, 'longest' : "no", 'cdslen': 0, 'strand' : strand, 
-                                                        'exons' : {}, "gene-id" : parent_id, 'start-frame' : "",
+                                                        'exons' : {}, "gene-id" : parent_id, 'start-frame' : None,
                                                         0 : 0, 2 : 0, 3 : 0, 4 : 0 };
                     # Add the ID and related info to the annotation dict. This includes an empty dict for exons to be stored in a similar way
                     # The last 4 entries are counts for number of sites with each degeneracy to summarize transcripts

--- a/lib/gxf.py
+++ b/lib/gxf.py
@@ -40,7 +40,7 @@ def readFeatures(globs, file_reader, line_reader, feature_list, id_format, paren
             # Header/comment lines should be skipped. Note that this must come after the check for "##FASTA" above, or else
             # the file will keep being read into the sequences and error out.
 
-            feature_type, seq_header, start, end, strand, feature_info = line[2], line[0], int(line[3]), int(line[4]), line[6], line[8].split(info_field_splitter);
+            feature_type, seq_header, start, end, strand, frame, feature_info = line[2], line[0], int(line[3]), int(line[4]), line[6], line[7], line[8].split(info_field_splitter);
             # Unpack the pertinent information from the current line into more readable variables.
 
             if feature_type in feature_list:
@@ -68,7 +68,8 @@ def readFeatures(globs, file_reader, line_reader, feature_list, id_format, paren
                 # Unpack and parse the gene ID
 
                 if feature_list[0] == "transcript":
-                    globs['annotation'][feature_id] = { 'header' : seq_header, 'start' : start, 'end' : end, 'len' : end-start, 'longest' : "no", 'cdslen': 0, 'strand' : strand, 'exons' : {}, "gene-id" : parent_id,
+                    globs['annotation'][feature_id] = { 'header' : seq_header, 'start' : start, 'end' : end, 'len' : end-start, 'longest' : "no", 'cdslen': 0, 'strand' : strand, 
+                                                        'exons' : {}, "gene-id" : parent_id, 'start-frame' : "",
                                                         0 : 0, 2 : 0, 3 : 0, 4 : 0 };
                     # Add the ID and related info to the annotation dict. This includes an empty dict for exons to be stored in a similar way
                     # The last 4 entries are counts for number of sites with each degeneracy to summarize transcripts
@@ -91,6 +92,15 @@ def readFeatures(globs, file_reader, line_reader, feature_list, id_format, paren
 
                     globs['annotation'][parent_id]['exons'][exon_id] = { 'header' : seq_header, 'start' : start, 'end' : end, 'len' : end-start, 'strand' : strand };
                     globs['annotation'][parent_id]['cdslen'] += end-start;
+
+                    if strand == "+" and num_exons == 0:
+                        globs['annotation'][transcript]['start-frame'] = frame;
+                    
+                    if strand == "-":
+                        globs['annotation'][transcript]['start-frame'] = frame;
+                    
+                    #If on the positive strand, the starting frame is always the frame of the first exon we encounter
+                    #If on the negative strand, the starting frame is awlays the frame of the last exon we encounter, so we just update it each time we see a new exon
                 # Add the ID and related info to the annotation dict.                   
 
                 num_features += 1;

--- a/lib/gxf.py
+++ b/lib/gxf.py
@@ -64,7 +64,7 @@ def readFeatures(globs, file_reader, line_reader, feature_list, id_format, paren
                 parent_id = parent_id[0].replace(parent_id_format, "").replace("\"", "");
                 # Unpack and parse the gene ID
 
-                if feature_list[0] == "transcript":
+                if feature_list[0] == "transcript" or feature_list[0] == "mRNA":
 
                     checkIDs(line, feature_info, feature_id, feature_list[0] +" id parsing", globs);
                     # A quick check to make sure we have read only one ID

--- a/lib/gxf.py
+++ b/lib/gxf.py
@@ -15,6 +15,7 @@ def checkIDs(l, info, id_list, step, globs):
 
     if len(id_list) != 1:
         print("\n\n");
+        print(len(id_list));
         print(id_list);
         print(info);
         print(l);
@@ -64,11 +65,10 @@ def readFeatures(globs, file_reader, line_reader, feature_list, id_format, paren
                 parent_id = parent_id[0].replace(parent_id_format, "").replace("\"", "");
                 # Unpack and parse the gene ID
 
-                if feature_list[0] == "transcript" or feature_list[0] == "mRNA":
+                if feature_list[0] == "transcript":
 
                     checkIDs(line, feature_info, feature_id, feature_list[0] +" id parsing", globs);
                     # A quick check to make sure we have read only one ID
-
 
                     globs['annotation'][feature_id] = { 'header' : seq_header, 'start' : start, 'end' : end, 'len' : end-start, 'longest' : "no", 'cdslen': 0, 'strand' : strand, 
                                                         'exons' : {}, "gene-id" : parent_id, 'start-frame' : "",

--- a/lib/gxf.py
+++ b/lib/gxf.py
@@ -41,7 +41,7 @@ def readFeatures(globs, file_reader, line_reader, feature_list, id_format, paren
             # Header/comment lines should be skipped. Note that this must come after the check for "##FASTA" above, or else
             # the file will keep being read into the sequences and error out.
 
-            feature_type, seq_header, start, end, strand, frame, feature_info = line[2], line[0], int(line[3]), int(line[4]), line[6], line[7], line[8].split(info_field_splitter);
+            feature_type, seq_header, start, end, strand, phase, feature_info = line[2], line[0], int(line[3]), int(line[4]), line[6], line[7], line[8].split(info_field_splitter);
             # Unpack the pertinent information from the current line into more readable variables.
 
             if feature_type in feature_list:
@@ -68,7 +68,7 @@ def readFeatures(globs, file_reader, line_reader, feature_list, id_format, paren
                     # Unpack and parse the ID
 
                     globs['annotation'][feature_id] = { 'header' : seq_header, 'start' : start, 'end' : end, 'len' : end-start, 'longest' : "no", 'cdslen': 0, 'strand' : strand, 
-                                                        'exons' : {}, "gene-id" : parent_id, 'start-frame' : None,
+                                                        'exons' : {}, "gene-id" : parent_id, 'start-frame' : None, 'coding-start' : None,
                                                         0 : 0, 2 : 0, 3 : 0, 4 : 0 };
                     # Add the ID and related info to the annotation dict. This includes an empty dict for exons to be stored in a similar way
                     # The last 4 entries are counts for number of sites with each degeneracy to summarize transcripts
@@ -89,17 +89,9 @@ def readFeatures(globs, file_reader, line_reader, feature_list, id_format, paren
                     # Because exon IDs are not always included for CDS, or they only represent the CDS as a whole (e.g. protein ID from Ensembl), we 
                     # count the number of exons in the transcript as the ID
 
-                    globs['annotation'][parent_id]['exons'][exon_id] = { 'header' : seq_header, 'start' : start, 'end' : end, 'len' : end-start, 'strand' : strand };
+                    globs['annotation'][parent_id]['exons'][exon_id] = { 'header' : seq_header, 'start' : start, 'end' : end, 'len' : end-start, 'strand' : strand, 'phase' :  phase};
                     globs['annotation'][parent_id]['cdslen'] += end-start;
 
-                    if strand == "+" and num_exons == 0:
-                        globs['annotation'][parent_id]['start-frame'] = int(frame);
-                    
-                    if strand == "-":
-                        globs['annotation'][parent_id]['start-frame'] = int(frame);
-                    
-                    #If on the positive strand, the starting frame is always the frame of the first exon we encounter
-                    #If on the negative strand, the starting frame is awlays the frame of the last exon we encounter, so we just update it each time we see a new exon
                 # Add the ID and related info to the annotation dict.                   
 
                 num_features += 1;

--- a/lib/gxf.py
+++ b/lib/gxf.py
@@ -93,10 +93,10 @@ def readFeatures(globs, file_reader, line_reader, feature_list, id_format, paren
                     globs['annotation'][parent_id]['cdslen'] += end-start;
 
                     if strand == "+" and num_exons == 0:
-                        globs['annotation'][parent_id]['start-frame'] = frame;
+                        globs['annotation'][parent_id]['start-frame'] = int(frame);
                     
                     if strand == "-":
-                        globs['annotation'][parent_id]['start-frame'] = frame;
+                        globs['annotation'][parent_id]['start-frame'] = int(frame);
                     
                     #If on the positive strand, the starting frame is always the frame of the first exon we encounter
                     #If on the negative strand, the starting frame is awlays the frame of the last exon we encounter, so we just update it each time we see a new exon

--- a/lib/output.py
+++ b/lib/output.py
@@ -45,9 +45,14 @@ def compileBedLine(globs, transcript, transcript_region, cds_coord, base, codon,
             new_codon = list(codon);
             new_codon[codon_pos] = new_base;
             new_codon = "".join(new_codon);
-            new_aa = cdict[new_codon];
-            # Replace the reference base with the new base at the current codon
-            # position and look up the new AA
+
+            try:
+                new_aa = cdict[new_codon];
+                # Replace the reference base with the new base at the current codon
+                # position and look up the new AA
+            except KeyError:
+                print("Error: ", new_codon, base_degen, codon, transcript)
+                continue
 
             if aa != new_aa:
                 subs.append(new_base + ":" + new_aa);

--- a/lib/params.py
+++ b/lib/params.py
@@ -101,7 +101,7 @@ def init():
         'bases' : ['A', 'T', 'C', 'G'],
         # List of standard nucleotides
 
-        'leading-bases' : { 0 : 0, 1 : 1, 2 : 2 },
+        'leading-bases' : { 0 : 0, 1 : 2, 2 : 1 },
         # The number of bases to remove from the beginning of a seq
         # for each frame. frame:num bases
 

--- a/lib/params.py
+++ b/lib/params.py
@@ -101,7 +101,7 @@ def init():
         'bases' : ['A', 'T', 'C', 'G'],
         # List of standard nucleotides
 
-        'leading-bases' : { 1 : 0, 2 : 1, 3 : 2 },
+        'leading-bases' : { 0 : 0, 1 : 1, 2 : 2 },
         # The number of bases to remove from the beginning of a seq
         # for each frame. frame:num bases
 

--- a/lib/params.py
+++ b/lib/params.py
@@ -101,10 +101,6 @@ def init():
         'bases' : ['A', 'T', 'C', 'G'],
         # List of standard nucleotides
 
-        'leading-bases' : { 0 : 0, 1 : 2, 2 : 1 },
-        # The number of bases to remove from the beginning of a seq
-        # for each frame. frame:num bases
-
         'info' : False,
         'quiet' : False,
         # Other user options

--- a/lib/seq.py
+++ b/lib/seq.py
@@ -123,13 +123,22 @@ def extractCDS(globs):
         # Add check to make sure exons all have same strand as transcript?
 
         exon_coords = { exons[exon]['start']-1 : exons[exon]['end'] for exon in exons };
+        exon_phase = { exons[exon]['start'] : exons[exon]['phase'] for exon in exons };
         # Get the coordinates of all the exons in this transcript
         # Subtract 1 from the starting coord because GXF are 1-based and python strings are 0-based
 
         if strand == "+":
             sorted_starts = sorted(list(exon_coords.keys()));
+            globs['annotation'][transcript]['coding-start'] = int(sorted_starts[0])+1
+            #convert back to genome coords from python string coords
+            globs['annotation'][transcript]['start-frame'] = int(exon_phase[int(sorted_starts[0])+1])
+
         elif strand == "-":
             sorted_starts = sorted(list(exon_coords.keys()), reverse=True);
+            globs['annotation'][transcript]['coding-start'] = int(exon_coords[sorted_starts[0]])
+            #the end position of the last exon is the coding start, where last exon = first sorted starts because sorted starts is reversed
+            globs['annotation'][transcript]['start-frame'] = int(exon_phase[int(exon_coords[sorted_starts[0]])])
+            
         # Make sure the exons are sorted correctly, reversing the order if the strand is "-"
 
         for start in sorted_starts:

--- a/lib/seq.py
+++ b/lib/seq.py
@@ -131,7 +131,10 @@ def extractCDS(globs):
             sorted_starts = sorted(list(exon_coords.keys()));
             globs['annotation'][transcript]['coding-start'] = int(sorted_starts[0])+1
             #convert back to genome coords from python string coords
-            globs['annotation'][transcript]['start-frame'] = int(exon_phase[int(sorted_starts[0])+1])
+            try: 
+                globs['annotation'][transcript]['start-frame'] = int(exon_phase[int(sorted_starts[0])+1])
+            except KeyError:
+                print(transcript, exon_phase, sorted_starts)
 
         elif strand == "-":
             sorted_starts = sorted(list(exon_coords.keys()), reverse=True);

--- a/lib/seq.py
+++ b/lib/seq.py
@@ -137,7 +137,7 @@ def extractCDS(globs):
             sorted_starts = sorted(list(exon_coords.keys()), reverse=True);
             globs['annotation'][transcript]['coding-start'] = int(exon_coords[sorted_starts[0]])
             #the end position of the last exon is the coding start, where last exon = first sorted starts because sorted starts is reversed
-            globs['annotation'][transcript]['start-frame'] = int(exon_phase[int(exon_coords[sorted_starts[0]])])
+            globs['annotation'][transcript]['start-frame'] = int(exon_phase[exon_coords[sorted_starts[0]+1]])
             
         # Make sure the exons are sorted correctly, reversing the order if the strand is "-"
 

--- a/lib/seq.py
+++ b/lib/seq.py
@@ -132,13 +132,6 @@ def extractCDS(globs):
 
         elif strand == "-":
             sorted_starts = sorted(list(exon_coords.keys()), reverse=True);
-            first_codon_gc = sorted_starts[0] + 1;
-            
-            #the end position of the last exon is the coding start, where last exon = first sorted starts because sorted starts is reversed
-            try:
-                globs['annotation'][transcript]['start-frame'] = int(exon_phase[exon_coords[sorted_starts[0] + 1]])
-            except KeyError:
-                print(transcript, genome_start, exon_phase, sorted_starts)
          
         first_exon_genome_start = sorted_starts[0] + 1;
         first_exon_genome_end = exon_coords[sorted_starts[0]]

--- a/lib/seq.py
+++ b/lib/seq.py
@@ -129,21 +129,23 @@ def extractCDS(globs):
 
         if strand == "+":
             sorted_starts = sorted(list(exon_coords.keys()));
-            globs['annotation'][transcript]['coding-start'] = int(sorted_starts[0])+1
+            genome_start = sorted_starts[0] + 1;
+            globs['annotation'][transcript]['coding-start'] = genome_start
             #convert back to genome coords from python string coords
             try: 
-                globs['annotation'][transcript]['start-frame'] = int(exon_phase[int(sorted_starts[0])+1])
+                globs['annotation'][transcript]['start-frame'] = int(exon_phase[genome_start])
             except KeyError:
                 print(transcript, exon_phase, sorted_starts)
 
         elif strand == "-":
             sorted_starts = sorted(list(exon_coords.keys()), reverse=True);
-            globs['annotation'][transcript]['coding-start'] = int(exon_coords[sorted_starts[0]])
+            genome_start = exon_coords[sorted_starts[0] + 1];
+            globs['annotation'][transcript]['coding-start'] = genome_start
             #the end position of the last exon is the coding start, where last exon = first sorted starts because sorted starts is reversed
             try:
-                globs['annotation'][transcript]['start-frame'] = int(exon_phase[exon_coords[sorted_starts[0]+1]])
+                globs['annotation'][transcript]['start-frame'] = int(exon_phase[exon_coords[sorted_starts[0] + 1]])
             except KeyError:
-                print(transcript, exon_phase, sorted_starts)
+                print(transcript, genome_start, exon_phase, sorted_starts)
             
         # Make sure the exons are sorted correctly, reversing the order if the strand is "-"
 

--- a/lib/seq.py
+++ b/lib/seq.py
@@ -96,6 +96,10 @@ def extractCDS(globs):
 
     for transcript in globs['annotation']:
 
+        if len(globs['annotation'][transcript]['exons']) == 0:
+            continue;
+            #no exons means this transcript does not have a CDS, so we skip it
+
         cur_seq = "";
         # Initialize the sequence string for the current transcript. This will be added to the 'seqs' dict later
 

--- a/lib/seq.py
+++ b/lib/seq.py
@@ -129,24 +129,27 @@ def extractCDS(globs):
 
         if strand == "+":
             sorted_starts = sorted(list(exon_coords.keys()));
-            genome_start = sorted_starts[0] + 1;
-            globs['annotation'][transcript]['coding-start'] = genome_start
-            #convert back to genome coords from python string coords
-            try: 
-                globs['annotation'][transcript]['start-frame'] = int(exon_phase[genome_start])
-            except KeyError:
-                print(transcript, exon_phase, sorted_starts)
 
         elif strand == "-":
             sorted_starts = sorted(list(exon_coords.keys()), reverse=True);
-            genome_start = exon_coords[sorted_starts[0] + 1];
-            globs['annotation'][transcript]['coding-start'] = genome_start
+            first_codon_gc = sorted_starts[0] + 1;
+            
             #the end position of the last exon is the coding start, where last exon = first sorted starts because sorted starts is reversed
             try:
                 globs['annotation'][transcript]['start-frame'] = int(exon_phase[exon_coords[sorted_starts[0] + 1]])
             except KeyError:
                 print(transcript, genome_start, exon_phase, sorted_starts)
-            
+         
+        first_exon_genome_start = sorted_starts[0] + 1;
+        first_exon_genome_end = exon_coords[sorted_starts[0]]
+
+        if strand == "+":
+            globs['annotation'][transcript]['coding-start'] = first_exon_genome_start
+        elif strand == "-":
+            globs['annotation'][transcript]['coding-start'] = first_exon_genome_end
+        
+        globs['annotation'][transcript]['start-frame'] = int(exon_phase[first_exon_genome_start])
+
         # Make sure the exons are sorted correctly, reversing the order if the strand is "-"
 
         for start in sorted_starts:

--- a/lib/seq.py
+++ b/lib/seq.py
@@ -140,7 +140,10 @@ def extractCDS(globs):
             sorted_starts = sorted(list(exon_coords.keys()), reverse=True);
             globs['annotation'][transcript]['coding-start'] = int(exon_coords[sorted_starts[0]])
             #the end position of the last exon is the coding start, where last exon = first sorted starts because sorted starts is reversed
-            globs['annotation'][transcript]['start-frame'] = int(exon_phase[exon_coords[sorted_starts[0]+1]])
+            try:
+                globs['annotation'][transcript]['start-frame'] = int(exon_phase[exon_coords[sorted_starts[0]+1]])
+            except KeyError:
+                print(transcript, exon_phase, sorted_starts)
             
         # Make sure the exons are sorted correctly, reversing the order if the strand is "-"
 


### PR DESCRIPTION
This pull request updates how we handle partial transcripts:

- Starting frame is now parsed from the GXF file, and used to trim the 5' end of a transcript (accounting for strand) to account for partial first codons.
- Partial 3' codons (accounting for strand) are correctly handled
- Degeneracy for partial codons is always '.', even if a different degeneracy could plausibly be inferred
- Non-ATGC bases (N as well as degenerate bases like R and W) are handled correctly, and generate a '.' for degeneracy for the entire codon.

This also includes some bugfixes for ID parsing from GTF files (where CDS features may have no ID)