### PR TITLE
Add MK test functionality and options to write amino acid sequences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ lib/*.pyc
 *.errlog
 test-out
 mk-test-*
+test-data/mm10/ncbi/GCF_000001635.27_GRCm39_genomic.fna.gz
+test-data/mm10/ncbi/GCF_000001635.27_GRCm39_genomic.fna.gz.fai
+test-data/mm10/ncbi/GCF_000001635.27_GRCm39_genomic.fna.gz.gzi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
+2023.01.26
+- Fixed bug when reading feature info from a gxf file and the field splitter remained on the last entry, causing no exons to be read
+- Added scipy dependency for Fisher's test
+- Implemented MK test (outputs raw p-value and odds ratio, which is equivalent to the neutrality index) and DoS statistic (from https://doi.org/10.1093/molbev/msq249)
+- Added `-ca` and `-la` to write amino acid sequences when specified, which necessitated adding the bioTranslator() and readCodonTable() functions
+- Changed how `-c`, `-ca`, `-l`, and `-la` behaved, allowing users to provide a file name, but using a default if none is provided
+
 2022.11.21
-- Added `-l` to extract CDS sequences from longest transcripts and exit.
+- Added `-l` to extract CDS sequences from longest transcripts and exit
 
 2022.11.16
 - Numerous bugfixes in McDonald-Kreitman test calculations

--- a/degenotate_lib/gxf.py
+++ b/degenotate_lib/gxf.py
@@ -44,6 +44,11 @@ def readFeatures(globs, file_reader, line_reader, feature_list, id_format, paren
             feature_type, seq_header, start, end, strand, phase, feature_info = line[2], line[0], int(line[3]), int(line[4]), line[6], line[7], line[8].split(info_field_splitter);
             # Unpack the pertinent information from the current line into more readable variables.
 
+            if feature_info[-1] == ";":
+                feature_info[-1] = feature_info[-1][:-1];
+            # For gtf files, the field splitter includes a space ("; "), meaning the last entry of feature_info will still contain a ; (since it ends ";\n")
+            # Remove that trailing ; here.
+
             if feature_type in feature_list:
             # Skipping any 'unconfirmed_transcript'
 

--- a/degenotate_lib/output.py
+++ b/degenotate_lib/output.py
@@ -114,7 +114,7 @@ def initializeMKFile(mkfilename):
 # Opens the MK output file and writes the headers
 
     mkfile = open(mkfilename, "w");
-    cols = ['transcript', 'pN', 'pS', 'dN', 'dS'];
+    cols = ['transcript', 'pN', 'pS', 'dN', 'dS', 'mk.raw.p.value', 'mk.odds.ni', 'dos'];
     mkfile.write("\t".join(cols) + "\n");
     return mkfile;
 
@@ -123,7 +123,7 @@ def initializeMKFile(mkfilename):
 def writeMK(transcript, outdict, mk_stream):
 # A function to write out MK tables for each transcript
 
-    outline = [ transcript, str(outdict['pn']), str(outdict['ps']), str(outdict['dn']), str(outdict['ds']) ]
+    outline = [ transcript, str(outdict['pn']), str(outdict['ps']), str(outdict['dn']), str(outdict['ds']), str(outdict['mk.pval']), str(outdict['mk.odds.ni']), str(outdict['dos']) ];
     mk_stream.write("\t".join(outline) + "\n");
         
 #############################################################################

--- a/degenotate_lib/params.py
+++ b/degenotate_lib/params.py
@@ -26,7 +26,7 @@ class StrictDict(dict):
 
 def init():
     globs_init = {
-        'version' : '1.0.0',
+        'version' : '1.1.0',
         'releasedate' : "November 2022",
         'authors' : "Timothy Sackton, Gregg Thomas",
         'doi' : '',

--- a/degenotate_lib/params.py
+++ b/degenotate_lib/params.py
@@ -7,6 +7,7 @@
 #############################################################################
 
 import sys
+import os
 import timeit
 import degenotate_lib.core as PC
 
@@ -70,12 +71,17 @@ def init():
         'outmk'  : 'mk.tsv',
         'outseq' : False,
         'write-cds' : False,
+        'write-cds-aa' : False,
         'write-longest' : False,
+        'write-longest-aa' : False,
         'run-name' : 'degenotate',
         'logfilename' : 'degenotate.errlog',
         'logdir' : '',
         'overwrite' : False,
         # I/O options
+
+        'genetic-code-file' : os.path.join(os.path.dirname(__file__), "codon-table.csv"),
+        # The file with the genetic code
 
         'shortest-paths' : False,
         # Dependency functions


### PR DESCRIPTION
This pull request includes these changes:
- Fixed bug when reading feature info from a gxf file and the field splitter remained on the last entry, causing no exons to be read
- Added scipy dependency for Fisher's test
- Implemented MK test (outputs raw p-value and odds ratio, which is equivalent to the neutrality index) and DoS statistic (from https://doi.org/10.1093/molbev/msq249)
- Added `-ca` and `-la` to write amino acid sequences when specified, which necessitated adding the bioTranslator() and readCodonTable() functions
- Changed how `-c`, `-ca`, `-l`, and `-la` behaved, allowing users to provide a file name, but using a default if none is provided