### PR TITLE
Fixed bugs related to invariant/missing sites in VCF files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,4 @@ test-data/mm10/ncbi/GCF_000001635.27_GRCm39_genomic.fna.gz.fai
 test-data/mm10/ncbi/GCF_000001635.27_GRCm39_genomic.fna.gz.gzi
 test-data/issue*
 environment-old.yml
+issue23-out/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+2023.02.02
+- Added check to skip invariant sites in the VCF file
+- Added a check to skip sites where there are no alleles in the outgroup, which could happen in the case of missing data or for variant sites in which all the alternate alleles are among excluded samples. In the latter case, the program would crash because it would try to select an allele from an empty list
+
 2023.01.30
 - We now skip transcripts with 0 length in the input annotation and print warnings about them in the log file
 - Updated `environment.yml` to include the [scipy](https://anaconda.org/conda-forge/scipy) dependency

--- a/degenotate_lib/gxf.py
+++ b/degenotate_lib/gxf.py
@@ -114,7 +114,6 @@ def readFeatures(globs, file_reader, line_reader, feature_list, id_format, paren
 
                     globs['annotation'][parent_id]['exons'][exon_id] = { 'header' : seq_header, 'start' : start, 'end' : end, 'len' : end-start, 'strand' : strand, 'phase' :  phase};
                     globs['annotation'][parent_id]['cdslen'] += end-start+1;
-
                 # Add the ID and related info to the annotation dict.                   
 
                 num_features += 1;

--- a/degenotate_lib/opt_parse.py
+++ b/degenotate_lib/opt_parse.py
@@ -395,7 +395,7 @@ def startProg(globs):
             # Report VCF outgroup samples
 
             if globs['vcf-exclude']:
-                CORE.printWrite(globs['logfilename'], globs['log-v'], CORE.spacedOut("# -i", pad) +
+                CORE.printWrite(globs['logfilename'], globs['log-v'], CORE.spacedOut("# -e", pad) +
                         CORE.spacedOut(",".join(globs['vcf-exclude']), opt_pad) +
                         " These samples will be excluded in the VCF file.");  
             # Report samples to exclude in the input VCF

--- a/degenotate_lib/params.py
+++ b/degenotate_lib/params.py
@@ -26,7 +26,7 @@ class StrictDict(dict):
 
 def init():
     globs_init = {
-        'version' : '1.1.1',
+        'version' : '1.1.2',
         'releasedate' : "January 2023",
         'authors' : "Timothy Sackton, Gregg Thomas",
         'doi' : '',


### PR DESCRIPTION
When reading a VCF file, in the case that all ingroup and outgroup alleles are missing, the program would crash because it would still try to select an outgroup allele as a fixed difference. This PR resolves that issue and also adds a check for invariant sites to be skipped in case the input file is a gvcf.