### PR TITLE
Negative strand variant bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,4 @@ test-data/mm10/ncbi/GCF_000001635.27_GRCm39_genomic.fna.gz.gzi
 test-data/issue*
 environment-old.yml
 issue23-out/
+test-data/vidmac/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+2023.02.07
+- Fixed bug that miscounted substitutions on transcripts on the negative strand since the variants in the VCF file are all reported on the positive strand with respect to the reference
+
 2023.02.06
 - Added `-m` option so user can specify minimum transcript length, with a default value (and global minimum) of 3bp
 

--- a/degenotate_lib/params.py
+++ b/degenotate_lib/params.py
@@ -116,6 +116,10 @@ def init():
         'bases' : ['A', 'T', 'C', 'G'],
         # List of standard nucleotides
 
+        'complement' : { 'A' : 'T', 'C' : 'G', 'G' : 'C', 'T' : 'A', 'N' : 'N',
+                         'a' : 't', 'c' : 'g', 'g' : 'c', 't' : 'a', 'n' : 'n'  },
+        # The complement of each base character
+
         'info' : False,
         'quiet' : False,
         # Other user options

--- a/degenotate_lib/seq.py
+++ b/degenotate_lib/seq.py
@@ -128,10 +128,6 @@ def extractCDS(globs):
     step_start_time = CORE.report_step(globs, step, False, "In progress...");
     # Status update
 
-    complement = { 'A' : 'T', 'C' : 'G', 'G' : 'C', 'T' : 'A', 'N' : 'N',
-                   'a' : 't', 'c' : 'g', 'g' : 'c', 't' : 'a', 'n' : 'n'  };
-    # A dictionary with base complements for use when reverse complementing sequences
-
     for transcript in globs['annotation']:
 
         if len(globs['annotation'][transcript]['exons']) == 0:
@@ -198,7 +194,7 @@ def extractCDS(globs):
             # The list of genome coordinates in the current CDS
 
             if strand == "-": 
-                cur_exon_seq = "".join(complement.get(base, base) for base in reversed(cur_exon_seq));
+                cur_exon_seq = "".join(globs['complement'].get(base, base) for base in reversed(cur_exon_seq));
                 # Reverse complement the sequence of the current CDS
                 
                 genome_coord_list.reverse(); 

--- a/degenotate_lib/vcf.py
+++ b/degenotate_lib/vcf.py
@@ -145,6 +145,11 @@ def getVariants(globs, transcript, transcript_region, codons, extra_leading_nt, 
                 continue;
             # Look up the alleles at the current position and if there are no alternate alleles (invariant site), skip
 
+            if strand == "-":
+                alt_nts = [ globs['complement'][base] for base in alt_nts ];    
+            # For transcripts on the negative strand, the alternate alleles in the VCF
+            # need to be complemented      
+
             rec_pos = rec.start + 1
             # Adjust 0-based pysam coordinate to 1-based gff coordinate here
 
@@ -231,7 +236,7 @@ def getVariants(globs, transcript, transcript_region, codons, extra_leading_nt, 
                 mk_codons[rec_codon_pos]['fixed-flag'] = True;
 
                 if len(out_allele_counts) == 1:
-                    mk_codons[rec_codon_pos]['fixed'][codon_pos] = alt_nts[list(out_allele_counts)[0]-1];
+                    mk_codons[rec_codon_pos]['fixed'][codon_pos] = alt_nts[list(out_allele_counts)[0]-1];                   
                 # If there is only one allele in the outgroup (the site is not polymorphic in the outgroup)
                 # add that allele to the fixed_diff_codon by looking it up in the alt_nts list
                 
@@ -251,6 +256,8 @@ def getVariants(globs, transcript, transcript_region, codons, extra_leading_nt, 
         mk_codons[codon_index]['poly'] = [ "".join(poly_codon) for poly_codon in mk_codons[codon_index]['poly'] ];    
         mk_codons[codon_index]['fixed'] = "".join(mk_codons[codon_index]['fixed']);
     # Convert the polymorphic_codons from lists to strings
+
+    #print(mk_codons);
 
     return mk_codons;
 


### PR DESCRIPTION
Fixed a bug in which substitutions were miscounted on transcripts on the negative strand because variants in the vcf file are reported on the positive strand. This was fixed by simply complementing the alternate alleles in the vcf that occur on transcripts on the negative strand,