### PR TITLE
added -maf and --no-fixed-in options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,4 @@ environment-old.yml
 issue23-out/
 test-data/vidmac/
 test-data/Ecoracana/
+stash.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+2023.04.26
+- Added the `-maf` option that allows the user to specify a minor allele frequency cutoff for ingroups in the MK tests; alleles below the specified frequency will be excluded. The default `-maf` cutoff is 1 / 2N where N is the number of ingroup samples.
+- Added `--no-fixed-ingroup` option that will exclude sites from MK tests if all ingroup samples are fixed for an alternate allele, which is likely an error in the reference
+
 2023.04.20
 - Converted error for transcripts with exons on differing strands to a warning, and added warning for transcripts with no coding exons
 

--- a/degenotate_lib/core.py
+++ b/degenotate_lib/core.py
@@ -175,6 +175,22 @@ def isPosInt(numstr, default=False, minval=1, maxval=False):
 
 #############################################################################
 
+def isPosFloat(numstr, default=False, minval=0.0, maxval=False):
+# Check if a string is a positive float
+    try:
+        num = float(numstr);
+    except:
+        return default;
+
+    if num < minval:
+        return default;
+    elif maxval and num > maxval:
+        return default;
+    else:
+        return num;        
+
+#############################################################################
+
 def printWrite(o_name, v, o_line1, o_line2="", pad=0):
 # Function to print a string AND write it to the file.
     if o_line2 == "":

--- a/degenotate_lib/params.py
+++ b/degenotate_lib/params.py
@@ -58,6 +58,7 @@ def init():
         'vcf-index-exts' : ['.tbi', '.csi'],
         'vcf' : False,
         'vcf-ingroups' : [],
+        'num-ingroup-chr' : False,
         'vcf-outgroups' : False,
         'vcf-exclude' : [],
         # Input VCF file
@@ -101,13 +102,23 @@ def init():
         # Degeneracy output
 
         'nonsyn' : {},
-        #output of syn/nonsyn snp calculations
+        # output of syn/nonsyn snp calculations
 
         'annotation' : {},
         'genekey' : {},
         'min-len' : 3,
         'short-transcripts' : [],
         # Annotation information
+
+        'count-fixed-alt-ingroups' : True,
+        # For MK tests, whether or not to count sites where all ingroup samples share an allele that differs
+        # from the reference, which could just be an error in the reference
+
+        'ingroup-maf-cutoff' : False,
+        # The frequency cutoff for the minor allele in the ingroups to be considered in the MK tests
+        # Alleles present BELOW this frequency will not be considered
+        # Currently defaults to 1 / 2N, where N is the number of ingroup samples, so this has to be calculated
+        # after we read the VCF
 
         'num-procs' : 1,
         # Number of processes to use; currently multiprocessing not implemented


### PR DESCRIPTION
- `-maf` is an option to specify a cutoff for the minor allele frequency. Any alleles present below this frequency in the ingroup samples will be ignored for MK tests. The default is 1 / 2N where N is the number of ingroup samples.
- `--no-fixed-in` can be used to ignore sites where all ingroup samples are homozygous for the same alternate allele rather than counting this as a polymorphism. 