### PR TITLE
Fix bug when GFF info field has trailing semi-colon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+2023.08.31
+- Added a check for trailing semi-colons in GFF file info fields
+
 2023.08.29
 - Fixed bug with processing CDS fasta files
 

--- a/degenotate_lib/gxf.py
+++ b/degenotate_lib/gxf.py
@@ -44,6 +44,9 @@ def readFeatures(globs, file_reader, line_reader, feature_list, id_format, paren
             feature_type, seq_header, start, end, strand, phase, feature_info = line[2], line[0], int(line[3]), int(line[4]), line[6], line[7], line[8].split(info_field_splitter);
             # Unpack the pertinent information from the current line into more readable variables.
 
+            feature_info = list(filter(None, feature_info));
+            # Remove empty strings from the feature list in case the gff field has a trailing semicolon
+
             if feature_info[-1][-1] == ";":
                 feature_info[-1] = feature_info[-1][:-1];
             # For gtf files, the field splitter includes a space ("; "), meaning the last entry of feature_info will still contain a ; (since it ends ";\n")

--- a/degenotate_lib/params.py
+++ b/degenotate_lib/params.py
@@ -26,7 +26,7 @@ class StrictDict(dict):
 
 def init():
     globs_init = {
-        'version' : '1.2.3',
+        'version' : '1.2.4',
         'releasedate' : "August 2023",
         'authors' : "Timothy Sackton, Gregg Thomas",
         'doi' : '',


### PR DESCRIPTION
Related to #39.

Feature info lists are now filtered of empty strings. 